### PR TITLE
Delay response

### DIFF
--- a/ExampleTests/ExampleTests.swift
+++ b/ExampleTests/ExampleTests.swift
@@ -43,4 +43,136 @@ class ExampleTests: XCTestCase {
             XCTAssertNil(error)
         }
     }
+    
+    func testMultipleRequestExample() {
+        let bundle = Bundle(for: ExampleTests.self)
+        guard let path = bundle.path(forResource: "GET", ofType: "json"), let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else { XCTFail(); return }
+        let expect1 = expectation(description: "1")
+        let expect2 = expectation(description: "2")
+        
+        YetAnotherURLProtocol.stubHTTP { (session) in
+            session.whenRequest(matcher: http(.get, uri: "/get"))
+                .thenResponse(responseBuilder: jsonData(data, status: 200))
+            
+            session.whenRequest(matcher: http(.get, uri: "/get?show_env=1&page=1"))
+            .thenResponse(responseBuilder: jsonString("{\"args\":{\"page\": 1,\"show_env\": 1}}", status: 200))
+        }
+        
+        Alamofire.request("https://httpbin.org/get").responseJSON { (response) in
+            XCTAssertTrue(response.result.isSuccess)
+            XCTAssertFalse(response.result.isFailure)
+            let dict = response.result.value as? [String: Any]
+            XCTAssertNotNil(dict)
+            let originIp = dict!["origin"] as! String
+            XCTAssertEqual(originIp, "9.9.9.9")
+            expect1.fulfill()
+        }
+        
+        Alamofire.request("https://httpbin.org/get?show_env=1&page=1").responseJSON { (response) in
+            XCTAssertTrue(response.result.isSuccess)
+            XCTAssertFalse(response.result.isFailure)
+            let dict = response.result.value as? [String: Any]
+            let args = dict!["args"] as! [String: Any]
+            XCTAssertNotNil(args)
+            XCTAssertEqual(args["show_env"] as! Int, 1)
+            expect2.fulfill()
+        }
+        wait(for: [expect1, expect2], timeout: 5)
+    }
+    
+    func testMultipleResponseExample() {
+        let expect1 = expectation(description: "1")
+        let expect2 = expectation(description: "2")
+        let expect3 = expectation(description: "3")
+        
+        YetAnotherURLProtocol.stubHTTP { (session) in
+            session.whenRequest(matcher: http(.get, uri: "/polling"))
+                .thenResponse(responseBuilder: jsonString("{\"status\": 0}", status: 200))
+                .thenResponse(responseBuilder: jsonString("{\"status\": 0}", status: 200))
+                .thenResponse(responseBuilder: jsonString("{\"status\": 1}", status: 200))
+        }
+        
+        let response3: (DataResponse<Any>) -> Void = { (response) in
+            XCTAssertTrue(response.result.isSuccess)
+            XCTAssertFalse(response.result.isFailure)
+            let dict = response.result.value as! [String: Int]
+            XCTAssertEqual(dict["status"], 1)
+            expect3.fulfill()
+        }
+        let response2: (DataResponse<Any>) -> Void = { [response3] (response) in
+            XCTAssertTrue(response.result.isSuccess)
+            XCTAssertFalse(response.result.isFailure)
+            expect2.fulfill()
+            self.httpRequest(forURL: "https://httpbin.org/polling", closure: response3)
+        }
+        let response1: (DataResponse<Any>) -> Void = { [response2] (response) in
+            XCTAssertTrue(response.result.isSuccess)
+            XCTAssertFalse(response.result.isFailure)
+            expect1.fulfill()
+            self.httpRequest(forURL: "https://httpbin.org/polling", closure: response2)
+        }
+        httpRequest(forURL: "https://httpbin.org/polling", closure: response1)
+     
+        wait(for: [expect1, expect2, expect3], timeout: 5)
+    }
+    
+    func testSimpleExampleWithDelay() {
+        let delay: TimeInterval = 5
+        let bundle = Bundle(for: ExampleTests.self)
+        guard let path = bundle.path(forResource: "GET", ofType: "json"), let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else { XCTFail(); return }
+        
+        YetAnotherURLProtocol.stubHTTP { (session) in
+            session.whenRequest(matcher: http(.get, uri: "/get"))
+                .thenResponse(withDelay: delay, responseBuilder: jsonData(data, status: 200))
+        }
+        
+        let expect = expectation(description: "")
+        Alamofire.request("https://httpbin.org/get").responseJSON { (response) in
+            XCTAssertTrue(response.result.isSuccess)
+            XCTAssertFalse(response.result.isFailure)
+            expect.fulfill()
+        }
+        waitForExpectations(timeout: delay + 1) { (error) in
+            XCTAssertNil(error)
+        }
+    }
+    
+    func testRequestFailedIfStubSessionSetupIncomplete() {
+        let customQueue = DispatchQueue(label: "custom.queue")
+        YetAnotherURLProtocol.stubHTTP { (session) in
+            session.whenRequest(matcher: http(.get, uri: "/noResponse"))
+
+            session.whenRequest(matcher: http(.get, uri: "/partialResponse"))
+                .responseOn(queue: customQueue)
+        }
+        
+        let expect1 = expectation(description: "1")
+        let expect2 = expectation(description: "2")
+        
+        let response2: (DataResponse<Any>) -> Void = { (response) in
+            if case .failure(let error) = response.result {
+                XCTAssertEqual((error as! StubError).message, "Cannot process partial response for this request https://httpbin.org/partialResponse")
+            } else {
+                XCTFail()
+            }
+            expect2.fulfill()
+        }
+        let response1: (DataResponse<Any>) -> Void = { (response) in
+            if case .failure(let error) = response.result {
+                XCTAssertEqual((error as! StubError).message, "There isn't any(more) response for this request https://httpbin.org/noResponse")
+            } else {
+                XCTFail()
+            }
+            expect1.fulfill()
+        }
+        
+        httpRequest(forURL: "https://httpbin.org/noResponse", closure: response1)
+        httpRequest(forURL: "https://httpbin.org/partialResponse", closure: response2)
+        
+        wait(for: [expect1, expect2], timeout: 5)
+    }
+    
+    fileprivate func httpRequest(forURL urlstring: String, closure: @escaping ((DataResponse<Any>) -> Void)) {
+        Alamofire.request(urlstring).responseJSON(completionHandler: closure)
+    }
 }

--- a/README.md
+++ b/README.md
@@ -108,6 +108,18 @@ YetAnotherURLProtocol.stubHTTP { (session) in
 }
 ```
 
+You can also delay the reply of StubResponse now. The delay value will only apply to the StubResponse that you specify.
+
+```swift
+let delay: TimeInterval = 5
+YetAnotherURLProtocol.stubHTTP { (session) in
+    session.whenRequest(matcher:  http(.get, uri: "/status"))
+    .thenResponse(withDelay: delay, responseBuilder: jsonString("{\"status\": 1}", status: 200))
+}
+```
+
+##### Checkout the test in Example target for more detail.
+
 ## Donation
 
 <table>

--- a/YetAnotherHTTPStub/StubRequest.swift
+++ b/YetAnotherHTTPStub/StubRequest.swift
@@ -34,16 +34,22 @@ public class StubRequest: NSObject {
     }
     
     @discardableResult
-    public func thenResponse(responseBuilder: @escaping Builder) -> Self {
+    public func thenResponse(withDelay delay: TimeInterval = 0, responseBuilder: @escaping Builder) -> Self {
         guard let lastResponse = responses.last else {
-            responses.append(StubResponse().assign(builder: responseBuilder))
+            responses.append(StubResponse()
+                .setResponseDelay(delay)
+                .assign(builder: responseBuilder))
             return self
         }
         if lastResponse.isPartial {
             let index = responses.count - 1
-            responses[index] = lastResponse.assign(builder: responseBuilder)
+            responses[index] = lastResponse
+                .setResponseDelay(delay)
+                .assign(builder: responseBuilder)
         } else {
-            responses.append(StubResponse(queue: lastResponse.queue).assign(builder: responseBuilder))
+            responses.append(StubResponse(queue: lastResponse.queue)
+                .setResponseDelay(delay)
+                .assign(builder: responseBuilder))
         }
         
         return self

--- a/YetAnotherHTTPStub/StubResponse.swift
+++ b/YetAnotherHTTPStub/StubResponse.swift
@@ -10,7 +10,7 @@ import Foundation
 
 // MARK: - Error
 public struct StubError: Error, Equatable {
-    var message: String
+    public var message: String
     var localizedDescription: String {
         return message
     }
@@ -57,6 +57,7 @@ public class StubResponse: NSObject {
     private(set) var builder: Builder?
     private(set) var queue: DispatchQueue
     fileprivate var postReplyClosure: (() -> Void) = { }
+    private(set) var delay: TimeInterval = 0
     
     var isPartial: Bool {
         return builder == nil
@@ -81,10 +82,16 @@ public class StubResponse: NSObject {
         self.postReplyClosure = postReply
         return self
     }
+
+    @discardableResult
+    func setResponseDelay(_ delay: TimeInterval) -> StubResponse {
+        self.delay = delay
+        return self
+    }
     
     public func reply(via urlProtocol: URLProtocol) {
         guard let builder = builder else { return }
-        queue.async {
+        queue.asyncAfter(deadline: DispatchTime.now() + delay) {
             let request = urlProtocol.request
             let response = builder(request)
             let client = urlProtocol.client

--- a/YetAnotherHTTPStubTests/StubResponseTests.swift
+++ b/YetAnotherHTTPStubTests/StubResponseTests.swift
@@ -173,4 +173,29 @@ class StubResponseTests: XCTestCase {
         XCTAssertFalse(client.clientDidReceiveResponse)
         XCTAssertFalse(client.clientDidLoadData)
     }
+    
+    func testSetDelayToStubResponse() {
+        XCTAssertEqual(StubResponse().setResponseDelay(5).delay, 5)
+    }
+    
+    func testGetResponseAfterDelay() {
+        let delay: TimeInterval = 5
+        let fakeProtocol = FakeURLProtocol(request: request, cachedResponse: nil, client: client)
+        let expect = expectation(description: "get")
+        
+        let response = StubResponse().setResponseDelay(delay).assign(builder: http(200)).setPostReply {
+            expect.fulfill()
+        }
+        response.reply(via: fakeProtocol)
+        
+        waitForExpectations(timeout: delay + 1) { (error) in
+            XCTAssertNil(error)
+        }
+        XCTAssertTrue(client.clientDidReceiveResponse)
+        XCTAssertFalse(client.clientDidLoadData)
+        let receivedResponse = client.response
+        XCTAssertNotNil(receivedResponse)
+        XCTAssertEqual(receivedResponse?.statusCode, 200)
+        XCTAssertTrue(client.clientDidFinishLoading)
+    }
 }


### PR DESCRIPTION
I want to put a delay to the StubResponse that delay the reply to the request.
Maybe this can be useful to mimic some network condition or timeout.

Maybe the code can be like this:
```
YetAnotherURLProtocol.stubHTTP { (session) in
    session.whenRequest(matcher: http(.get, uri: "/get"))
                 .thenResponse(withDelay: 5, responseBuilder: jsonData(data, status: 200))
}
```