### PR TITLE
Update Matchers to handle URLs with brackets and plus signs

### DIFF
--- a/YetAnotherHTTPStub/Matchers.swift
+++ b/YetAnotherHTTPStub/Matchers.swift
@@ -21,7 +21,17 @@ public func uri(_ uri:String) -> (_ urlrequest: URLRequest) -> Bool {
         guard let urlstring = urlrequest.url?.absoluteString, let _ = urlrequest.url?.path else {
             return false
         }
-        let predicate = NSPredicate(format: "SELF MATCHES %@", uri.replacingOccurrences(of: "?", with: "\\?"))
+        guard var encodedUri = uri.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed) else {
+            return false
+        }
+        //restore wildcard backslashes that were encoded
+        encodedUri = encodedUri.replacingOccurrences(of: "%5C", with: "\\")
+
+        //escape regex characters
+        encodedUri = encodedUri.replacingOccurrences(of: "?", with: "\\?")
+        encodedUri = encodedUri.replacingOccurrences(of: "+", with: "\\+")
+        
+        let predicate = NSPredicate(format: "SELF MATCHES %@", encodedUri)
 
         if predicate.evaluate(with: urlstring) { return true }
         

--- a/YetAnotherHTTPStubTests/MatchersTests.swift
+++ b/YetAnotherHTTPStubTests/MatchersTests.swift
@@ -15,6 +15,8 @@ class MatchersTests: XCTestCase {
     var invalidRequest: URLRequest!
     var urlWithPathRequest: URLRequest!
     var urlWithQueryRequest: URLRequest!
+    var urlWithBracketsRequest: URLRequest!
+    var urlWithPlusRequest: URLRequest!
     var forInvalidQueryTestRequest: URLRequest!
     override func setUp() {
         super.setUp()
@@ -25,6 +27,10 @@ class MatchersTests: XCTestCase {
         urlWithPathRequest = URLRequest(url: URL(string: "https://www.httpbin.org/user-agent")!)
         urlWithQueryRequest = URLRequest(url: URL(string: "https://www.httpbin.org/get?show_env=1&page=2")!)
         urlWithQueryRequest.httpMethod = "GET"
+        urlWithBracketsRequest = URLRequest(url: URL(string: "https://www.httpbin.org/get?show_env[]=1")!)
+        urlWithBracketsRequest.httpMethod = "GET"
+        urlWithPlusRequest = URLRequest(url: URL(string: "https://www.httpbin.org/get?query+test=1")!)
+        urlWithPlusRequest.httpMethod = "GET"
         forInvalidQueryTestRequest = URLRequest(url: URL(string: "https://www.httpbin.org/get?show_env=1&page=a")!)
     }
     
@@ -94,5 +100,12 @@ class MatchersTests: XCTestCase {
 
     func testMethodWithPathAndWildcardMismatch() {
         XCTAssertFalse(http(.patch, uri: "/get?show_env=\\d&page=\\d")(urlWithQueryRequest))
+    }
+    // special characters
+    func testMethodWithBracketCharacters() {
+        XCTAssertTrue(http(.get, uri: "/get?show_env[]=1")(urlWithBracketsRequest))
+    }
+    func testMethodWithPlusSign() {
+        XCTAssertTrue(http(.get, uri: "/get?query+test=1")(urlWithPlusRequest))
     }
 }


### PR DESCRIPTION
This fix handles the case of the symbols +, [, and ] in a path